### PR TITLE
[Feature/#4] 메인페이지 파트별 지원서 조회 기능 구현

### DIFF
--- a/src/MainDummy.json
+++ b/src/MainDummy.json
@@ -1,0 +1,24 @@
+{
+  "applications": [
+    {
+      "id": "6c055818-01d0-48f4-85aa-ba523e410a16",
+      "name": "이진혁",
+      "studentId": "60201886",
+      "phoneNumber": "010-2424-2323",
+      "part": "SERVER",
+      "major": "컴퓨터공학과",
+      "createdAt": "2024-02-18T22:35:36.691+00:00",
+      "link": "https://github.com/mju-likelion/custard-pudding"
+    },
+    {
+      "id": "5656002b-5cc6-4987-8f39-433722c8f8bd",
+      "name": "김대현",
+      "studentId": "60201880",
+      "phoneNumber": "010-2424-2323",
+      "part": "SERVER",
+      "major": "화학공학과",
+      "createdAt": "2024-02-18T22:37:35.743+00:00",
+      "link": "https://github.com/mju-likelion/custard-pudding"
+    }
+  ]
+}

--- a/src/api/getApplication.js
+++ b/src/api/getApplication.js
@@ -1,14 +1,12 @@
 import { Axios } from './Axios';
 
-export const getApplication = async () => {
+export const getApplication = async (part, pageNum) => {
   try {
-    const part = 'web';
-    const pageNum = 1;
     const response = await Axios.get(
       `/applications?part=${part}&pageNum=${pageNum}`,
     );
     console.log(response);
-    return response;
+    return response.data.data;
   } catch (error) {
     console.log(error);
   }

--- a/src/api/getApplication.js
+++ b/src/api/getApplication.js
@@ -1,0 +1,15 @@
+import { Axios } from './Axios';
+
+export const getApplication = async () => {
+  try {
+    const part = 'web';
+    const pageNum = 1;
+    const response = await Axios.get(
+      `/applications?part=${part}&pageNum=${pageNum}`,
+    );
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/api/postLogin.js
+++ b/src/api/postLogin.js
@@ -1,0 +1,14 @@
+import { Axios } from './Axios';
+
+export const postLogin = async () => {
+  try {
+    const response = await Axios.post(`/auth/login`, {
+      managerId: 'a',
+      password: 'a',
+    });
+    console.log(response.data);
+    return response.data.statusCode;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -5,11 +5,30 @@ import MAIN_DUMMY from '../MainDummy.json';
 import styled from 'styled-components';
 
 const Main = () => {
+  const [applicationData, setApplicationData] = useState(false);
   const [isLoggedin, setIsLoggedin] = useState(false);
   const [currentPart, setCurrentPart] = useState('web');
+  const [currentPageNumber, setcurrentPageNumber] = useState(1);
 
   const data = MAIN_DUMMY.applications;
   const titleList = Object.keys(data[0]);
+
+  function renderButtons(totalPageNumber) {
+    const buttons = [];
+    for (let i = 0; i < totalPageNumber; i++) {
+      buttons.push(
+        <PageButton
+          key={i}
+          $pageNumber={i + 1}
+          $currentPageNumber={currentPageNumber}
+          onClick={() => setcurrentPageNumber(i + 1)}
+        >
+          Button {i + 1}
+        </PageButton>,
+      );
+    }
+    return buttons;
+  }
 
   useEffect(() => {
     const login = async () => {
@@ -21,14 +40,17 @@ const Main = () => {
   }, []);
 
   useEffect(() => {
-    console.log(isLoggedin);
     const fetchData = async () => {
       if (isLoggedin) {
-        const applicationData = await getApplication();
+        const applicationData = await getApplication(
+          currentPart,
+          currentPageNumber,
+        );
+        setApplicationData(applicationData);
       }
     };
     fetchData();
-  }, [isLoggedin]);
+  }, [isLoggedin, currentPageNumber]);
 
   return (
     <div>
@@ -52,7 +74,7 @@ const Main = () => {
           Server
         </Button>
       </ButtonBox>
-      {data && (
+      {applicationData && (
         <ContentContainer border="1">
           <Title>
             {titleList.map((t) => (
@@ -61,7 +83,7 @@ const Main = () => {
             ))}
           </Title>
           <>
-            {data?.map((application) => (
+            {applicationData?.applications?.map((application) => (
               <>
                 <Application key={application.id}>
                   <Id>{application.id}</Id>
@@ -82,9 +104,7 @@ const Main = () => {
           </>
         </ContentContainer>
       )}
-      <PageNumber>
-        <Page></Page>
-      </PageNumber>
+      <PageNumberBox>{renderButtons(applicationData.totalPage)}</PageNumberBox>
     </div>
   );
 };
@@ -121,6 +141,21 @@ const Link = styled.a`
   text-underline-position: under;
   text-decoration-thickness: 1px;
 `;
-const PageNumber = styled.div``;
-const Page = styled.div``;
+const PageNumberBox = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+`;
+const PageButton = styled.button`
+  background-color: ${({ $pageNumber, $currentPageNumber }) =>
+    $pageNumber === $currentPageNumber ? 'pink' : 'white'};
+  padding: 10px;
+  border: 1px solid
+    ${({ $pageNumber, $currentPageNumber }) =>
+      $pageNumber === $currentPageNumber ? 'white' : 'pink'};
+  color: ${({ $pageNumber, $currentPageNumber }) =>
+    $pageNumber === $currentPageNumber ? 'white' : 'pink'};
+  border-radius: 8px;
+  cursor: pointer;
+`;
 export default Main;

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,17 +1,17 @@
+import styled from 'styled-components';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { postLogin } from '../api/postLogin';
 import { getApplication } from '../api/getApplication';
-import MAIN_DUMMY from '../MainDummy.json';
-import styled from 'styled-components';
 
 const Main = () => {
-  const [applicationData, setApplicationData] = useState(false);
+  const navigate = useNavigate();
+
+  const [applicationData, setApplicationData] = useState([]);
+  const [titleList, setTitleList] = useState([]);
   const [isLoggedin, setIsLoggedin] = useState(false);
   const [currentPart, setCurrentPart] = useState('web');
   const [currentPageNumber, setcurrentPageNumber] = useState(1);
-
-  const data = MAIN_DUMMY.applications;
-  const titleList = Object.keys(data[0]);
 
   function renderButtons(totalPageNumber) {
     const buttons = [];
@@ -23,7 +23,7 @@ const Main = () => {
           $currentPageNumber={currentPageNumber}
           onClick={() => setcurrentPageNumber(i + 1)}
         >
-          Button {i + 1}
+          {i + 1}
         </PageButton>,
       );
     }
@@ -47,10 +47,11 @@ const Main = () => {
           currentPageNumber,
         );
         setApplicationData(applicationData);
+        setTitleList(Object.keys(applicationData?.applications[0]));
       }
     };
     fetchData();
-  }, [isLoggedin, currentPageNumber]);
+  }, [isLoggedin, currentPart, currentPageNumber]);
 
   return (
     <div>
@@ -58,6 +59,7 @@ const Main = () => {
         <Button
           onClick={() => {
             setCurrentPart('web');
+            setcurrentPageNumber(1);
           }}
           $part="web"
           $curpart={currentPart}
@@ -67,6 +69,7 @@ const Main = () => {
         <Button
           onClick={() => {
             setCurrentPart('server');
+            setcurrentPageNumber(1);
           }}
           $part="server"
           $curpart={currentPart}
@@ -81,6 +84,7 @@ const Main = () => {
               // eslint-disable-next-line react/jsx-key
               <th>{t}</th>
             ))}
+            <th>자기소개서</th>
           </Title>
           <>
             {applicationData?.applications?.map((application) => (
@@ -92,11 +96,23 @@ const Main = () => {
                   <Content>{application.phoneNumber}</Content>
                   <Content>{application.part}</Content>
                   <Content>{application.major}</Content>
-                  <Content>{application.createdAt.slice(0, 10)}</Content>
                   <Content>
-                    <Link href={application.link} target="_blank">
+                    {`${application.createdAt.slice(2, 10)}\n(${application.createdAt.slice(11, 19)})`}
+                  </Content>
+                  <Content>
+                    <Link
+                      href={application.link}
+                      target={currentPart === 'web' ? '_self' : '_blank'}
+                    >
                       {application.link}
                     </Link>
+                  </Content>
+                  <Content>
+                    <GoApplicationBtn
+                      onClick={() => navigate(`/${application.studentId}`)}
+                    >
+                      보기
+                    </GoApplicationBtn>
                   </Content>
                 </Application>
               </>
@@ -104,7 +120,7 @@ const Main = () => {
           </>
         </ContentContainer>
       )}
-      <PageNumberBox>{renderButtons(applicationData.totalPage)}</PageNumberBox>
+      <PageNumberBox>{renderButtons(applicationData?.totalPage)}</PageNumberBox>
     </div>
   );
 };
@@ -112,7 +128,10 @@ const Main = () => {
 const ContentContainer = styled.table`
   width: 100%;
 `;
-const ButtonBox = styled.div``;
+const ButtonBox = styled.div`
+  display: flex;
+  justify-content: end;
+`;
 const Button = styled.button`
   margin: 20px 10px;
   padding: 20px;
@@ -133,15 +152,29 @@ const Application = styled.tr`
   border: 3px solid #ffffff;
 `;
 const Id = styled.td`
-  font-size: 10px;
+  font-size: 11px;
 `;
-const Content = styled.td``;
+const Content = styled.td`
+  white-space: pre;
+  text-align: center;
+`;
+const GoApplicationBtn = styled.button`
+  background-color: #ffeef1;
+  font-weight: bold;
+  color: #ff798d;
+  border: 1px solid #ff798d;
+  border-radius: 8px;
+  cursor: pointer;
+`;
 const Link = styled.a`
   color: #ff798d;
+  font-size: 11px;
+  text-align: start;
   text-underline-position: under;
   text-decoration-thickness: 1px;
 `;
 const PageNumberBox = styled.div`
+  margin-top: 20px;
   display: flex;
   justify-content: center;
   gap: 20px;

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,5 +1,126 @@
+import { useEffect, useState } from 'react';
+import { postLogin } from '../api/postLogin';
+import { getApplication } from '../api/getApplication';
+import MAIN_DUMMY from '../MainDummy.json';
+import styled from 'styled-components';
+
 const Main = () => {
-  return <>메인 페이지</>;
+  const [isLoggedin, setIsLoggedin] = useState(false);
+  const [currentPart, setCurrentPart] = useState('web');
+
+  const data = MAIN_DUMMY.applications;
+  const titleList = Object.keys(data[0]);
+
+  useEffect(() => {
+    const login = async () => {
+      const loginStatusCode = await postLogin();
+      console.log(loginStatusCode);
+      setIsLoggedin(loginStatusCode === '200');
+    };
+    login();
+  }, []);
+
+  useEffect(() => {
+    console.log(isLoggedin);
+    const fetchData = async () => {
+      if (isLoggedin) {
+        const applicationData = await getApplication();
+      }
+    };
+    fetchData();
+  }, [isLoggedin]);
+
+  return (
+    <div>
+      <ButtonBox>
+        <Button
+          onClick={() => {
+            setCurrentPart('web');
+          }}
+          $part="web"
+          $curpart={currentPart}
+        >
+          Web
+        </Button>
+        <Button
+          onClick={() => {
+            setCurrentPart('server');
+          }}
+          $part="server"
+          $curpart={currentPart}
+        >
+          Server
+        </Button>
+      </ButtonBox>
+      {data && (
+        <ContentContainer border="1">
+          <Title>
+            {titleList.map((t) => (
+              // eslint-disable-next-line react/jsx-key
+              <th>{t}</th>
+            ))}
+          </Title>
+          <>
+            {data?.map((application) => (
+              <>
+                <Application key={application.id}>
+                  <Id>{application.id}</Id>
+                  <Content>{application.name}</Content>
+                  <Content>{application.studentId}</Content>
+                  <Content>{application.phoneNumber}</Content>
+                  <Content>{application.part}</Content>
+                  <Content>{application.major}</Content>
+                  <Content>{application.createdAt.slice(0, 10)}</Content>
+                  <Content>
+                    <Link href={application.link} target="_blank">
+                      {application.link}
+                    </Link>
+                  </Content>
+                </Application>
+              </>
+            ))}
+          </>
+        </ContentContainer>
+      )}
+      <PageNumber>
+        <Page></Page>
+      </PageNumber>
+    </div>
+  );
 };
 
+const ContentContainer = styled.table`
+  width: 100%;
+`;
+const ButtonBox = styled.div``;
+const Button = styled.button`
+  margin: 20px 10px;
+  padding: 20px;
+  font-size: 24px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background-color: ${({ $part, $curpart }) =>
+    $curpart === $part ? 'pink' : '#808080'};
+  color: ${({ $part, $curpart }) => ($curpart === $part ? 'white' : '#575757')};
+  font-weight: ${({ $part, $curpart }) => $curpart === $part && 'bold'};
+  cursor: pointer;
+`;
+const Title = styled.tr`
+  justify-content: space-around;
+  background-color: pink;
+`;
+const Application = styled.tr`
+  border: 3px solid #ffffff;
+`;
+const Id = styled.td`
+  font-size: 10px;
+`;
+const Content = styled.td``;
+const Link = styled.a`
+  color: #ff798d;
+  text-underline-position: under;
+  text-decoration-thickness: 1px;
+`;
+const PageNumber = styled.div``;
+const Page = styled.div``;
 export default Main;


### PR DESCRIPTION
## 📝 Summary
파트 별 지원서 정보를 불러오는 메인페이지 구현
-  (Web/Server) 파트 별 지원서 불러오기
-  항목을 클릭하면 해당 Detail페이지로 이동
- 서버 파트 지원 과제 새 탭에 띄우기
- 웹 파트 현재 탭에서 지원 과제 다운로드
- 페이지네이션

Closes #4 
