### PR TITLE
[Feature/#10] 새로고침이 되어도 선택된 상태를 유지하는 기능 구현

### DIFF
--- a/src/api/getApplication.js
+++ b/src/api/getApplication.js
@@ -1,12 +1,14 @@
 import { Axios } from './Axios';
 
-export const getApplication = async (part, pageNum, onlyPass) => {
+export const getApplication = async (part, pageNum, onlyPass, cancelToken) => {
   const isPassed = onlyPass ? '/passed' : '';
   try {
     const response = await Axios.get(
       `/applications${isPassed}?part=${part}&pageNum=${pageNum}`,
+      {
+        cancelToken: cancelToken,
+      },
     );
-    console.log(response);
     return response.data.data;
   } catch (error) {
     console.log(error);

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,4 @@ import './index.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+root.render(<App />);


### PR DESCRIPTION
## 📝 Summary
쿼리 파라미터를 사용해 새로고침을 해도 페이지번호, 파트, 합격자만 보기/전체 보기 상태가 유지 되는 기능 구현

useEffect가 비동기적으로 데이터를 가져오는 과정에서 값이 덮어씌워지는 문제(레이스 컨디션) 해결하기 위해 사용했던 CancelToken를 리팩토링 하면서 사용할 필요가 없어져서 삭제 했습니다.

Closes #10 
